### PR TITLE
Redirect official server requests

### DIFF
--- a/mitm-redirect.py
+++ b/mitm-redirect.py
@@ -69,11 +69,20 @@ class LocalRedirect:
     print('Loaded redirect addon')
 
   def request(self, flow: mitmproxy.http.HTTPFlow):
-    if ('api.sodoff.spirtix.com' in flow.request.pretty_host or 'api.jumpstart.com' in flow.request.pretty_host) and routable(flow.request.path):
+    if 'api.sodoff.spirtix.com' in flow.request.pretty_host and routable(flow.request.path):
       flow.request.host = "localhost"
       flow.request.scheme = 'http'
       flow.request.port = 5000
 
+class RedirectMediaRequests:
+  def __init__(self):
+    print('Loaded media request redirector')
+
+  def request(self, flow: mitmproxy.http.HTTPFlow):
+    if "media.jumpstart.com" in flow.request.pretty_host:
+      flow.request.host = "media.sodoff.spirtix.com"
+
 addons = [
   LocalRedirect()
+  RedirectMediaRequests()
 ]

--- a/mitm-redirect.py
+++ b/mitm-redirect.py
@@ -83,6 +83,6 @@ class RedirectMediaRequests:
       flow.request.host = "media.sodoff.spirtix.com"
 
 addons = [
-  LocalRedirect()
+  LocalRedirect(),
   RedirectMediaRequests()
 ]

--- a/mitm-redirect.py
+++ b/mitm-redirect.py
@@ -69,7 +69,7 @@ class LocalRedirect:
     print('Loaded redirect addon')
 
   def request(self, flow: mitmproxy.http.HTTPFlow):
-    if 'api.sodoff.spirtix.com' in flow.request.pretty_host and routable(flow.request.path):
+    if ('api.sodoff.spirtix.com' in flow.request.pretty_host or 'api.jumpstart.com' in flow.request.pretty_host) and routable(flow.request.path):
       flow.request.host = "localhost"
       flow.request.scheme = 'http'
       flow.request.port = 5000

--- a/mitm-redirect.py
+++ b/mitm-redirect.py
@@ -54,7 +54,17 @@ methods = [
   'GetAchievementsByUserID',
   'PurchaseItems',
   'AcceptMission',
-  'GetUserMissionState'
+  'GetUserMissionState',
+  'SetAchievementAndGetReward',
+  'SetUserAchievementTask',
+  'GetAnnouncementsByUser',
+  'GetUserRoomItemPositions',
+  'SetUserRoomItemPositions',
+  'GetAverageRatingForRoom',
+  'GetUserRoomList',
+  'GetUserActivityByUserID',
+  'SetNextItemState',
+  'SetUserRoom'
 ]
 
 def routable(path):


### PR DESCRIPTION
This (theoretically) allows users to use either your modified client, _or_ the original, which makes setup a little easier.  You still need to enable `ssl_insecure` in Mitmproxy's options, but that's already the case on current Master.