### PR TITLE
initial support for XP points

### DIFF
--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -15,11 +15,30 @@ public class AchievementController : Controller {
     }
 
     [HttpPost]
-    //[Produces("application/xml")]
+    [Produces("application/xml")]
     [Route("AchievementWebService.asmx/GetPetAchievementsByUserID")]
-    public IActionResult GetPetAchievementsByUserID() {
+    public IActionResult GetPetAchievementsByUserID([FromForm] string apiToken, [FromForm] string userId) {
+        Viking? viking = ctx.Sessions.FirstOrDefault(e => e.ApiToken == apiToken)?.Viking;
+        if (viking is null) {
+            return null;
+        }
+
+        List<UserAchievementInfo> dragonsAchievement = new List<UserAchievementInfo>();
+        foreach (Dragon dragon in viking.Dragons) { // TODO (multiplayer) we should use userId
+            dragonsAchievement.Add(new UserAchievementInfo{
+                PointTypeID = (int) AchievementPointTypes.DragonXP,
+                UserID = Guid.Parse(dragon.EntityId),
+                AchievementPointTotal = dragon.PetXP,
+                RankID = (int)dragon.PetXP/1024 + 1 // TODO: placeholder
+            });
+        }
+
+        ArrayOfUserAchievementInfo arrAchievements = new ArrayOfUserAchievementInfo {
+            UserAchievementInfo = dragonsAchievement.ToArray()
+        };
+
         // TODO, this is a placeholder
-        return Ok("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ArrayOfUserAchievementInfo xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://api.jumpstart.com/\" />");
+        return Ok(arrAchievements);
     }
 
     [HttpPost]
@@ -57,19 +76,19 @@ public class AchievementController : Controller {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 1
+                    PointTypeID = (int) AchievementPointTypes.PlayerXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 9
+                    PointTypeID = (int) AchievementPointTypes.PlayerFarmingXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 10
+                    PointTypeID = (int) AchievementPointTypes.PlayerFishingXP
                 },
             }
         };
@@ -86,7 +105,7 @@ public class AchievementController : Controller {
         return Ok(new AchievementReward[1] {
             new AchievementReward {
                 Amount = 5,
-                PointTypeID = 5,
+                PointTypeID = (int) AchievementPointTypes.CashCurrency,
                 EntityID = Guid.Parse(viking.Id),
                 EntityTypeID = 1,
                 RewardID = 552
@@ -112,7 +131,7 @@ public class AchievementController : Controller {
             AchievementRewards = new AchievementReward[1] {
                 new AchievementReward {
                     Amount = 25,
-                    PointTypeID = 1,
+                    PointTypeID = (int) AchievementPointTypes.PlayerXP,
                     RewardID = 910,
                     EntityTypeID =1
                 }
@@ -130,7 +149,7 @@ public class AchievementController : Controller {
         return Ok(new AchievementReward[1] {
             new AchievementReward {
                 Amount = 25,
-                PointTypeID = 1,
+                PointTypeID = (int) AchievementPointTypes.PlayerXP,
                 EntityID = Guid.Parse(viking.Id),
                 EntityTypeID = 1,
                 RewardID = 552

--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -4,14 +4,17 @@ using Microsoft.AspNetCore.Mvc;
 using sodoff.Attributes;
 using sodoff.Model;
 using sodoff.Schema;
+using sodoff.Services;
 using sodoff.Util;
 
 namespace sodoff.Controllers.Common;
 public class AchievementController : Controller {
 
     private readonly DBContext ctx;
-    public AchievementController(DBContext ctx) {
+    private RankService rankService;
+    public AchievementController(DBContext ctx, RankService rankService) {
         this.ctx = ctx;
+        this.rankService = rankService;
     }
 
     [HttpPost]
@@ -29,7 +32,7 @@ public class AchievementController : Controller {
                 PointTypeID = (int) AchievementPointTypes.DragonXP,
                 UserID = Guid.Parse(dragon.EntityId),
                 AchievementPointTotal = dragon.PetXP,
-                RankID = (int)dragon.PetXP/1024 + 1 // TODO: placeholder
+                RankID = rankService.getRankFromXP(dragon.PetXP, AchievementPointTypes.DragonXP)
             });
         }
 

--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -81,8 +81,8 @@ public class AchievementController : Controller {
         ArrayOfUserAchievementInfo arrAchievements = new ArrayOfUserAchievementInfo {
             UserAchievementInfo = new UserAchievementInfo[]{
                 achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
+                achievementService.userAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
+                achievementService.userAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
             }
         };
 

--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -31,7 +31,7 @@ public class AchievementController : Controller {
         List<UserAchievementInfo> dragonsAchievement = new List<UserAchievementInfo>();
         foreach (Dragon dragon in viking.Dragons) {
             dragonsAchievement.Add(
-                achievementService.userAchievementInfo(dragon.EntityId, dragon.PetXP, AchievementPointTypes.DragonXP)
+                achievementService.CreateUserAchievementInfo(dragon.EntityId, dragon.PetXP, AchievementPointTypes.DragonXP)
             );
         }
 
@@ -80,9 +80,9 @@ public class AchievementController : Controller {
 
         ArrayOfUserAchievementInfo arrAchievements = new ArrayOfUserAchievementInfo {
             UserAchievementInfo = new UserAchievementInfo[]{
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                achievementService.userAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
-                achievementService.userAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
+                achievementService.CreateUserAchievementInfo(viking, AchievementPointTypes.PlayerXP),
+                achievementService.CreateUserAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
+                achievementService.CreateUserAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
             }
         };
 

--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -11,10 +11,10 @@ namespace sodoff.Controllers.Common;
 public class AchievementController : Controller {
 
     private readonly DBContext ctx;
-    private RankService rankService;
-    public AchievementController(DBContext ctx, RankService rankService) {
+    private AchievementService achievementService;
+    public AchievementController(DBContext ctx, AchievementService achievementService) {
         this.ctx = ctx;
-        this.rankService = rankService;
+        this.achievementService = achievementService;
     }
 
     [HttpPost]
@@ -31,7 +31,7 @@ public class AchievementController : Controller {
         List<UserAchievementInfo> dragonsAchievement = new List<UserAchievementInfo>();
         foreach (Dragon dragon in viking.Dragons) {
             dragonsAchievement.Add(
-                rankService.userAchievementInfo(dragon.EntityId, dragon.PetXP, AchievementPointTypes.DragonXP)
+                achievementService.userAchievementInfo(dragon.EntityId, dragon.PetXP, AchievementPointTypes.DragonXP)
             );
         }
 
@@ -80,9 +80,9 @@ public class AchievementController : Controller {
 
         ArrayOfUserAchievementInfo arrAchievements = new ArrayOfUserAchievementInfo {
             UserAchievementInfo = new UserAchievementInfo[]{
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
             }
         };
 

--- a/src/Controllers/Common/AchievementController.cs
+++ b/src/Controllers/Common/AchievementController.cs
@@ -29,7 +29,7 @@ public class AchievementController : Controller {
         List<UserAchievementInfo> dragonsAchievement = new List<UserAchievementInfo>();
         foreach (Dragon dragon in viking.Dragons) { // TODO (multiplayer) we should use userId
             dragonsAchievement.Add(new UserAchievementInfo{
-                PointTypeID = (int) AchievementPointTypes.DragonXP,
+                PointTypeID = AchievementPointTypes.DragonXP,
                 UserID = Guid.Parse(dragon.EntityId),
                 AchievementPointTotal = dragon.PetXP,
                 RankID = rankService.getRankFromXP(dragon.PetXP, AchievementPointTypes.DragonXP)
@@ -79,19 +79,19 @@ public class AchievementController : Controller {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerXP
+                    PointTypeID = AchievementPointTypes.PlayerXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerFarmingXP
+                    PointTypeID = AchievementPointTypes.PlayerFarmingXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(userId),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerFishingXP
+                    PointTypeID = AchievementPointTypes.PlayerFishingXP
                 },
             }
         };
@@ -108,7 +108,7 @@ public class AchievementController : Controller {
         return Ok(new AchievementReward[1] {
             new AchievementReward {
                 Amount = 5,
-                PointTypeID = (int) AchievementPointTypes.CashCurrency,
+                PointTypeID = AchievementPointTypes.CashCurrency,
                 EntityID = Guid.Parse(viking.Id),
                 EntityTypeID = 1,
                 RewardID = 552
@@ -134,7 +134,7 @@ public class AchievementController : Controller {
             AchievementRewards = new AchievementReward[1] {
                 new AchievementReward {
                     Amount = 25,
-                    PointTypeID = (int) AchievementPointTypes.PlayerXP,
+                    PointTypeID = AchievementPointTypes.PlayerXP,
                     RewardID = 910,
                     EntityTypeID =1
                 }
@@ -152,7 +152,7 @@ public class AchievementController : Controller {
         return Ok(new AchievementReward[1] {
             new AchievementReward {
                 Amount = 25,
-                PointTypeID = (int) AchievementPointTypes.PlayerXP,
+                PointTypeID = AchievementPointTypes.PlayerXP,
                 EntityID = Guid.Parse(viking.Id),
                 EntityTypeID = 1,
                 RewardID = 552

--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -428,7 +428,7 @@ public class ContentController : Controller {
             return null;
         }
 
-        RaisedPetData[] dragons = viking.Dragons
+        RaisedPetData[] dragons = viking.Dragons // TODO (multiplayer) we should use userId
             .Where(d => d.RaisedPetData is not null)
             .Select(GetRaisedPetDataFromDragon)
             .ToArray();

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -144,9 +144,9 @@ public class ProfileController : Controller {
             RankID = 0, // placeholder
             AchievementInfo = null, // placeholder
             Achievements = new UserAchievementInfo[] {
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                achievementService.userAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
-                achievementService.userAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
+                achievementService.CreateUserAchievementInfo(viking, AchievementPointTypes.PlayerXP),
+                achievementService.CreateUserAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
+                achievementService.CreateUserAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
             }
         };
 

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -145,19 +145,19 @@ public class ProfileController : Controller {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerXP
+                    PointTypeID = AchievementPointTypes.PlayerXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerFarmingXP
+                    PointTypeID = AchievementPointTypes.PlayerFarmingXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = (int) AchievementPointTypes.PlayerFishingXP
+                    PointTypeID = AchievementPointTypes.PlayerFishingXP
                 },
             }
         };

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -2,14 +2,17 @@
 using Microsoft.AspNetCore.Mvc;
 using sodoff.Model;
 using sodoff.Schema;
+using sodoff.Services;
 using sodoff.Util;
 
 namespace sodoff.Controllers.Common;
 public class ProfileController : Controller {
 
     private readonly DBContext ctx;
-    public ProfileController(DBContext ctx) {
+    private RankService rankService;
+    public ProfileController(DBContext ctx, RankService rankService) {
         this.ctx = ctx;
+        this.rankService = rankService;
     }
 
     [HttpPost]
@@ -141,24 +144,9 @@ public class ProfileController : Controller {
             RankID = 0, // placeholder
             AchievementInfo = null, // placeholder
             Achievements = new UserAchievementInfo[] {
-                new UserAchievementInfo {
-                    UserID = Guid.Parse(viking.Id),
-                    AchievementPointTotal = 5000,
-                    RankID = 30,
-                    PointTypeID = AchievementPointTypes.PlayerXP
-                },
-                new UserAchievementInfo {
-                    UserID = Guid.Parse(viking.Id),
-                    AchievementPointTotal = 5000,
-                    RankID = 30,
-                    PointTypeID = AchievementPointTypes.PlayerFarmingXP
-                },
-                new UserAchievementInfo {
-                    UserID = Guid.Parse(viking.Id),
-                    AchievementPointTotal = 5000,
-                    RankID = 30,
-                    PointTypeID = AchievementPointTypes.PlayerFishingXP
-                },
+                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
+                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
+                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
             }
         };
 

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -145,8 +145,8 @@ public class ProfileController : Controller {
             AchievementInfo = null, // placeholder
             Achievements = new UserAchievementInfo[] {
                 achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
-                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
+                achievementService.userAchievementInfo(viking.Id, 60000, AchievementPointTypes.PlayerFarmingXP), // TODO: placeholder until there is no leveling for farm XP
+                achievementService.userAchievementInfo(viking.Id, 20000, AchievementPointTypes.PlayerFishingXP), // TODO: placeholder until there is no leveling for fishing XP
             }
         };
 

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -145,19 +145,19 @@ public class ProfileController : Controller {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 1
+                    PointTypeID = (int) AchievementPointTypes.PlayerXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 9
+                    PointTypeID = (int) AchievementPointTypes.PlayerFarmingXP
                 },
                 new UserAchievementInfo {
                     UserID = Guid.Parse(viking.Id),
                     AchievementPointTotal = 5000,
                     RankID = 30,
-                    PointTypeID = 10
+                    PointTypeID = (int) AchievementPointTypes.PlayerFishingXP
                 },
             }
         };

--- a/src/Controllers/Common/ProfileController.cs
+++ b/src/Controllers/Common/ProfileController.cs
@@ -9,10 +9,10 @@ namespace sodoff.Controllers.Common;
 public class ProfileController : Controller {
 
     private readonly DBContext ctx;
-    private RankService rankService;
-    public ProfileController(DBContext ctx, RankService rankService) {
+    private AchievementService achievementService;
+    public ProfileController(DBContext ctx, AchievementService achievementService) {
         this.ctx = ctx;
-        this.rankService = rankService;
+        this.achievementService = achievementService;
     }
 
     [HttpPost]
@@ -144,9 +144,9 @@ public class ProfileController : Controller {
             RankID = 0, // placeholder
             AchievementInfo = null, // placeholder
             Achievements = new UserAchievementInfo[] {
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
-                rankService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFarmingXP),
+                achievementService.userAchievementInfo(viking, AchievementPointTypes.PlayerFishingXP),
             }
         };
 

--- a/src/Model/AchievementPoints.cs
+++ b/src/Model/AchievementPoints.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace sodoff.Model;
+public class AchievementPoints {
+    public string VikingId { get; set; }
+
+    public int Type { get; set; }
+
+    public int Value { get; set; }
+
+    public virtual Viking? Viking { get; set; }
+}

--- a/src/Model/DBContext.cs
+++ b/src/Model/DBContext.cs
@@ -46,6 +46,9 @@ public class DBContext : DbContext {
         builder.Entity<Viking>().HasMany(v => v.Rooms)
             .WithOne(e => e.Viking);
 
+        builder.Entity<Viking>().HasMany(v => v.AchievementPoints)
+            .WithOne(e => e.Viking);
+
         builder.Entity<Viking>().HasOne(s => s.User)
             .WithMany(e => e.Vikings)
             .HasForeignKey(e => e.UserId);
@@ -130,5 +133,12 @@ public class DBContext : DbContext {
         builder.Entity<RoomItem>().HasOne(i => i.Room)
             .WithMany(r => r.Items)
             .HasForeignKey(e => e.RoomId);
+
+        builder.Entity<AchievementPoints>().HasKey(e => new { e.VikingId, e.Type });
+
+        builder.Entity<AchievementPoints>()
+            .HasOne(e => e.Viking)
+            .WithMany(e => e.AchievementPoints)
+            .HasForeignKey(e => e.VikingId);
     }
 }

--- a/src/Model/Dragon.cs
+++ b/src/Model/Dragon.cs
@@ -18,6 +18,8 @@ public class Dragon {
 
     public string? RaisedPetData { get; set; }
 
+    public int? PetXP { get; set; }
+    
     public virtual Viking Viking { get; set; } = null!;
     public virtual Viking SelectedViking { get; set; } = null!;
 }

--- a/src/Model/Viking.cs
+++ b/src/Model/Viking.cs
@@ -21,6 +21,7 @@ public class Viking {
     public virtual ICollection<Image> Images { get; set; } = null!;
     public virtual ICollection<MissionState> MissionStates { get; set; } = null!;
     public virtual ICollection<Room> Rooms { get; set; } = null!;
+    public virtual ICollection<AchievementPoints> AchievementPoints { get; set; } = null!;
     public virtual Dragon? SelectedDragon { get; set; }
 
     public int InventoryId { get; set; }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddSingleton<MissionStoreSingleton>();
 builder.Services.AddScoped<MissionService>();
 builder.Services.AddSingleton<StoreService>();
 builder.Services.AddScoped<RoomService>();
+builder.Services.AddSingleton<RankService>();
 
 var app = builder.Build();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddSingleton<MissionStoreSingleton>();
 builder.Services.AddScoped<MissionService>();
 builder.Services.AddSingleton<StoreService>();
 builder.Services.AddScoped<RoomService>();
-builder.Services.AddSingleton<RankService>();
+builder.Services.AddSingleton<AchievementService>();
 
 var app = builder.Build();
 

--- a/src/Schema/AchievementPointTypes.cs
+++ b/src/Schema/AchievementPointTypes.cs
@@ -1,0 +1,13 @@
+﻿using System.Xml.Serialization;
+
+namespace sodoff.Schema;
+
+public enum AchievementPointTypes {
+    PlayerXP = 1,
+    GameCurrency = 2, // gold
+    CashCurrency = 5, // gems
+    ItemReward = 6,
+    DragonXP = 8,
+    PlayerFarmingXP = 9,
+    PlayerFishingXP = 10,
+}

--- a/src/Schema/AchievementPointTypes.cs
+++ b/src/Schema/AchievementPointTypes.cs
@@ -3,11 +3,30 @@
 namespace sodoff.Schema;
 
 public enum AchievementPointTypes {
+    [XmlEnum("1")]
     PlayerXP = 1,
+    
+    [XmlEnum("2")]
     GameCurrency = 2, // gold
+    
+    [XmlEnum("4")]
+    Unused1 = 4, // unknown
+    
+    [XmlEnum("5")]
     CashCurrency = 5, // gems
+    
+    [XmlEnum("6")]
     ItemReward = 6,
+    
+    [XmlEnum("8")]
     DragonXP = 8,
+    
+    [XmlEnum("9")]
     PlayerFarmingXP = 9,
+    
+    [XmlEnum("10")]
     PlayerFishingXP = 10,
+    
+    [XmlEnum("12")]
+    UDTPoints = 12,
 }

--- a/src/Schema/AchievementPointTypes.cs
+++ b/src/Schema/AchievementPointTypes.cs
@@ -10,7 +10,7 @@ public enum AchievementPointTypes {
     GameCurrency = 2, // gold
     
     [XmlEnum("4")]
-    Unused1 = 4, // unknown
+    Unknown4 = 4,
     
     [XmlEnum("5")]
     CashCurrency = 5, // gems
@@ -29,4 +29,7 @@ public enum AchievementPointTypes {
     
     [XmlEnum("12")]
     UDTPoints = 12,
+    
+    [XmlEnum("13")]
+    Unknown13 = 13,
 }

--- a/src/Schema/AchievementReward.cs
+++ b/src/Schema/AchievementReward.cs
@@ -13,7 +13,7 @@ public class AchievementReward
 	public int? Amount;
 
 	[XmlElement(ElementName = "p", IsNullable = true)]
-	public int? PointTypeID;
+	public AchievementPointTypes? PointTypeID;
 
 	[XmlElement(ElementName = "ii")]
 	public int ItemID;

--- a/src/Schema/ArrayOfUserRank.cs
+++ b/src/Schema/ArrayOfUserRank.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics;
+using System.Xml.Serialization;
+
+namespace sodoff.Schema;
+
+[XmlRoot(ElementName = "ArrayOfUserRank", Namespace = "http://api.jumpstart.com/")]
+[Serializable]
+public class ArrayOfUserRank {
+    [XmlElement(ElementName = "UserRank")]
+    public UserRank[] UserRank;
+}

--- a/src/Schema/AvatarData.cs
+++ b/src/Schema/AvatarData.cs
@@ -7,6 +7,7 @@ namespace sodoff.Schema;
 public class AvatarData
 {
 	[XmlElement(ElementName = "IsSuggestedAvatarName", IsNullable = true)]
+	public bool? IsSuggestedAvatarName;
 
 	public int? Id;
 

--- a/src/Schema/ItemStateCriteriaReplenishable.cs
+++ b/src/Schema/ItemStateCriteriaReplenishable.cs
@@ -10,7 +10,7 @@ public class ItemStateCriteriaReplenishable : ItemStateCriteria
 	public bool ApplyRank;
 
 	[XmlElement(ElementName = "PointTypeID", IsNullable = true)]
-	public int? PointTypeID;
+	public AchievementPointTypes? PointTypeID;
 
 	[XmlElement(ElementName = "ReplenishableRates")]
 	public List<ReplenishableRate> ReplenishableRates;

--- a/src/Schema/RewardMultiplier.cs
+++ b/src/Schema/RewardMultiplier.cs
@@ -7,7 +7,7 @@ namespace sodoff.Schema;
 public class RewardMultiplier
 {
 	[XmlElement(ElementName = "PT")]
-	public int PointTypeID;
+	public AchievementPointTypes PointTypeID;
 
 	[XmlElement(ElementName = "MF")]
 	public int MultiplierFactor;

--- a/src/Schema/UserAchievementInfo.cs
+++ b/src/Schema/UserAchievementInfo.cs
@@ -19,7 +19,7 @@ public class UserAchievementInfo
 	public int RankID;
 
 	[XmlElement(ElementName = "p")]
-	public int? PointTypeID;
+	public AchievementPointTypes? PointTypeID;
 
 	[XmlElement(ElementName = "FBUID", IsNullable = true)]
 	public long? FacebookUserID;

--- a/src/Schema/UserRank.cs
+++ b/src/Schema/UserRank.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+using System.Xml.Serialization;
+
+namespace sodoff.Schema;
+
+[XmlRoot(ElementName = "UserRank", Namespace = "")]
+[Serializable]
+public class UserRank {
+    [XmlElement(ElementName = "PointTypeID")]
+    public AchievementPointTypes PointTypeID;
+
+    [XmlElement(ElementName = "Value")]
+    public int Value;
+
+    [XmlElement(ElementName = "RankID")]
+    public int? RankID;
+
+    [XmlElement(ElementName = "GlobalRankID")]
+    public int? GlobalRankID;
+}

--- a/src/Services/AchievementService.cs
+++ b/src/Services/AchievementService.cs
@@ -18,26 +18,26 @@ namespace sodoff.Services {
             }
         }
 
-        public int getRankFromXP(int? xpPoints, AchievementPointTypes type) {
+        public int GetRankFromXP(int? xpPoints, AchievementPointTypes type) {
             return ranks[type].Count(r => r.Value <= xpPoints);
         }
 
-        public UserAchievementInfo userAchievementInfo(string userId, int? value, AchievementPointTypes type) {
+        public UserAchievementInfo CreateUserAchievementInfo(string userId, int? value, AchievementPointTypes type) {
             if (value is null)
                 value = 0;
             return new UserAchievementInfo {
                 UserID = Guid.Parse(userId),
                 AchievementPointTotal = value,
-                RankID = getRankFromXP(value, type),
+                RankID = GetRankFromXP(value, type),
                 PointTypeID = type
             };
         }
 
-        public UserAchievementInfo userAchievementInfo(Viking viking, AchievementPointTypes type) {
-            return userAchievementInfo(viking.Id, viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type)?.Value, type);
+        public UserAchievementInfo CreateUserAchievementInfo(Viking viking, AchievementPointTypes type) {
+            return CreateUserAchievementInfo(viking.Id, viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type)?.Value, type);
         }
 
-        static public void addAchievementPoints(Viking viking, AchievementPointTypes? type, int? value) {
+        public void AddAchievementPoints(Viking viking, AchievementPointTypes? type, int? value) {
             if (type == AchievementPointTypes.DragonXP) {
                 viking.SelectedDragon.PetXP = (viking.SelectedDragon.PetXP ?? 0) + (value ?? 0);
             } else if (type != null) {

--- a/src/Services/AchievementService.cs
+++ b/src/Services/AchievementService.cs
@@ -6,11 +6,11 @@ using System.Xml;
 using System.Xml.Linq;
 
 namespace sodoff.Services {
-    public class RankService {
+    public class AchievementService {
 
         Dictionary<AchievementPointTypes, UserRank[]> ranks = new();
 
-        public RankService() {
+        public AchievementService() {
             ArrayOfUserRank allranks = XmlUtil.DeserializeXml<ArrayOfUserRank>(XmlUtil.ReadResourceXmlString("allranks"));
             
             foreach (var pointType in Enum.GetValues<AchievementPointTypes>()) {

--- a/src/Services/AchievementService.cs
+++ b/src/Services/AchievementService.cs
@@ -37,10 +37,10 @@ namespace sodoff.Services {
             return userAchievementInfo(viking.Id, viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type)?.Value, type);
         }
 
-        static public void setAchievementPoints(Viking viking, AchievementPointTypes? type, int? value) {
+        static public void addAchievementPoints(Viking viking, AchievementPointTypes? type, int? value) {
             if (type == AchievementPointTypes.DragonXP) {
-                viking.SelectedDragon.PetXP = viking.SelectedDragon.PetXP.GetValueOrDefault() + (int)value;
-            } else {
+                viking.SelectedDragon.PetXP = (viking.SelectedDragon.PetXP ?? 0) + (value ?? 0);
+            } else if (type != null) {
                 AchievementPoints xpPoints = viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type);
                 if (xpPoints is null) {
                     xpPoints = new AchievementPoints {
@@ -49,7 +49,7 @@ namespace sodoff.Services {
                     };
                     viking.AchievementPoints.Add(xpPoints);
                 }
-                xpPoints.Value += (int)value;
+                xpPoints.Value += value ?? 0;
             }
         }
     }

--- a/src/Services/MissionService.cs
+++ b/src/Services/MissionService.cs
@@ -60,6 +60,8 @@ public class MissionService {
                             viking.Inventory.InventoryItems.Add(ii);
                         }
                         ii.Quantity += (int)reward.Amount!;
+                    } else if (reward.PointTypeID == AchievementPointTypes.DragonXP || reward.PointTypeID == AchievementPointTypes.PlayerXP) {
+                        RankService.setAchievementPoints(viking, reward.PointTypeID, reward.Amount);
                     }
                 }
                 ctx.SaveChanges();

--- a/src/Services/MissionService.cs
+++ b/src/Services/MissionService.cs
@@ -49,7 +49,7 @@ public class MissionService {
                     missionState.UserAccepted = null;
                 }
                 foreach (var reward in mission.Rewards) {
-                    if (reward.PointTypeID == 6) {
+                    if (reward.PointTypeID == AchievementPointTypes.ItemReward) {
                         // TODO: This is not a pretty solution. Use inventory service in the future
                         InventoryItem? ii = viking.Inventory.InventoryItems.FirstOrDefault(x => x.ItemId == reward.ItemID);
                         if (ii is null) {

--- a/src/Services/MissionService.cs
+++ b/src/Services/MissionService.cs
@@ -60,8 +60,8 @@ public class MissionService {
                             viking.Inventory.InventoryItems.Add(ii);
                         }
                         ii.Quantity += (int)reward.Amount!;
-                    } else if (reward.PointTypeID == AchievementPointTypes.DragonXP || reward.PointTypeID == AchievementPointTypes.PlayerXP) {
-                        AchievementService.setAchievementPoints(viking, reward.PointTypeID, reward.Amount);
+                    } else { // currencies, all types of player XP and dragon XP
+                        AchievementService.addAchievementPoints(viking, reward.PointTypeID, reward.Amount);
                     }
                 }
                 ctx.SaveChanges();

--- a/src/Services/MissionService.cs
+++ b/src/Services/MissionService.cs
@@ -61,7 +61,7 @@ public class MissionService {
                         }
                         ii.Quantity += (int)reward.Amount!;
                     } else if (reward.PointTypeID == AchievementPointTypes.DragonXP || reward.PointTypeID == AchievementPointTypes.PlayerXP) {
-                        RankService.setAchievementPoints(viking, reward.PointTypeID, reward.Amount);
+                        AchievementService.setAchievementPoints(viking, reward.PointTypeID, reward.Amount);
                     }
                 }
                 ctx.SaveChanges();

--- a/src/Services/MissionService.cs
+++ b/src/Services/MissionService.cs
@@ -8,8 +8,9 @@ public class MissionService {
 
     private readonly DBContext ctx;
     private MissionStoreSingleton missionStore;
+    private AchievementService achievementService;
 
-    public MissionService(DBContext ctx, MissionStoreSingleton missionStore) {
+    public MissionService(DBContext ctx, MissionStoreSingleton missionStore, AchievementService achievementService) {
         this.ctx = ctx;
         this.missionStore = missionStore;
     }
@@ -61,7 +62,7 @@ public class MissionService {
                         }
                         ii.Quantity += (int)reward.Amount!;
                     } else { // currencies, all types of player XP and dragon XP
-                        AchievementService.addAchievementPoints(viking, reward.PointTypeID, reward.Amount);
+                        achievementService.AddAchievementPoints(viking, reward.PointTypeID, reward.Amount);
                     }
                 }
                 ctx.SaveChanges();

--- a/src/Services/RankService.cs
+++ b/src/Services/RankService.cs
@@ -1,0 +1,24 @@
+﻿using sodoff.Schema;
+using sodoff.Util;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace sodoff.Services {
+    public class RankService {
+
+        Dictionary<AchievementPointTypes, UserRank[]> ranks = new();
+
+        public RankService() {
+            ArrayOfUserRank allranks = XmlUtil.DeserializeXml<ArrayOfUserRank>(XmlUtil.ReadResourceXmlString("allranks"));
+            
+            foreach (var pointType in Enum.GetValues<AchievementPointTypes>()) {
+                ranks[pointType] = allranks.UserRank.Where(r => r.PointTypeID == pointType).ToArray();
+            }
+        }
+        
+        public int getRankFromXP(int? xpPoints, AchievementPointTypes type) {
+            return ranks[type].Count(r => r.Value <= xpPoints);
+        }
+    }
+}

--- a/src/Services/RankService.cs
+++ b/src/Services/RankService.cs
@@ -1,4 +1,5 @@
 ﻿using sodoff.Schema;
+using sodoff.Model;
 using sodoff.Util;
 using System.Reflection;
 using System.Xml;
@@ -16,9 +17,40 @@ namespace sodoff.Services {
                 ranks[pointType] = allranks.UserRank.Where(r => r.PointTypeID == pointType).ToArray();
             }
         }
-        
+
         public int getRankFromXP(int? xpPoints, AchievementPointTypes type) {
             return ranks[type].Count(r => r.Value <= xpPoints);
+        }
+
+        public UserAchievementInfo userAchievementInfo(string userId, int? value, AchievementPointTypes type) {
+            if (value is null)
+                value = 0;
+            return new UserAchievementInfo {
+                UserID = Guid.Parse(userId),
+                AchievementPointTotal = value,
+                RankID = getRankFromXP(value, type),
+                PointTypeID = type
+            };
+        }
+
+        public UserAchievementInfo userAchievementInfo(Viking viking, AchievementPointTypes type) {
+            return userAchievementInfo(viking.Id, viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type)?.Value, type);
+        }
+
+        static public void setAchievementPoints(Viking viking, AchievementPointTypes? type, int? value) {
+            if (type == AchievementPointTypes.DragonXP) {
+                viking.SelectedDragon.PetXP = viking.SelectedDragon.PetXP.GetValueOrDefault() + (int)value;
+            } else {
+                AchievementPoints xpPoints = viking.AchievementPoints.FirstOrDefault(a => a.Type == (int)type);
+                if (xpPoints is null) {
+                    xpPoints = new AchievementPoints {
+                        Type = (int)type,
+                        Value = 0
+                    };
+                    viking.AchievementPoints.Add(xpPoints);
+                }
+                xpPoints.Value += (int)value;
+            }
         }
     }
 }

--- a/src/Services/RoomService.cs
+++ b/src/Services/RoomService.cs
@@ -125,7 +125,7 @@ public class RoomService {
         if (rewards != null) {
             response.Rewards = rewards;
             foreach (var reward in rewards) {
-                if (reward.PointTypeID == 6) {
+                if (reward.PointTypeID == (int) AchievementPointTypes.ItemReward) {
                     // TODO: This is not a pretty solution. Use inventory service in the future
                     InventoryItem? ii = item.Room.Viking.Inventory.InventoryItems.FirstOrDefault(x => x.ItemId == reward.ItemID);
                     if (ii is null) {

--- a/src/Services/RoomService.cs
+++ b/src/Services/RoomService.cs
@@ -125,7 +125,7 @@ public class RoomService {
         if (rewards != null) {
             response.Rewards = rewards;
             foreach (var reward in rewards) {
-                if (reward.PointTypeID == (int) AchievementPointTypes.ItemReward) {
+                if (reward.PointTypeID == AchievementPointTypes.ItemReward) {
                     // TODO: This is not a pretty solution. Use inventory service in the future
                     InventoryItem? ii = item.Room.Viking.Inventory.InventoryItems.FirstOrDefault(x => x.ItemId == reward.ItemID);
                     if (ii is null) {


### PR DESCRIPTION
- support multiple types of player XP points
    - new db table - AchievementPoints
- support dragon XP
    - new column in dragons table
    - not use AchievementPoints table to make `AchievementPoints.VikingId == Vikings.Id` possible/simpler ... and dragons have only one type of XP
- add AchievementService for mapping points to rank and points managements
- use enum for PointTypeID